### PR TITLE
Implement `Hex`: Opaque Hex String Wrapper

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -26,7 +26,9 @@
     "elm/core": "1.0.5 <= v < 2.0.0",
     "elm/json": "1.1.3 <= v < 2.0.0",
     "elm-toulouse/cbor": "3.0.0 <= v < 4.0.0",
-    "jxxcarlson/hex": "4.0.0 <= v < 5.0.0"
+    "jxxcarlson/hex": "4.0.0 <= v < 5.0.0",
+    "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
+    "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
   },
   "test-dependencies": {
     "elm-explorations/test": "2.0.0 <= v < 3.0.0"

--- a/src/ElmCardano/MultiAsset.elm
+++ b/src/ElmCardano/MultiAsset.elm
@@ -14,12 +14,13 @@ module ElmCardano.MultiAsset exposing
 
 import Cbor.Encode as E
 import Dict exposing (Dict)
+import Hex.Extra exposing (Hex)
 
 
 {-| Opaque type for handling multi-asset values.
 -}
 type MultiAsset
-    = MultiAsset (Dict String (Dict String Int)) -- Dict PolicyId (Dict AssetName Int)
+    = MultiAsset (Dict Hex (Dict Hex Int)) -- Dict PolicyId (Dict AssetName Int)
 
 
 {-| Create an empty multi-asset value.

--- a/src/Hex/Extra.elm
+++ b/src/Hex/Extra.elm
@@ -61,7 +61,7 @@ toUTF8String hex =
             str
 
         Err _ ->
-            -- `Hex` can only be created with `fromString`, therefore this is
+            -- 'Hex' can only be created with 'fromString', therefore this is
             -- an impossible case and most likely an acceptable compromise.
             toHexString hex
 

--- a/src/Hex/Extra.elm
+++ b/src/Hex/Extra.elm
@@ -2,8 +2,8 @@ module Hex.Extra exposing
     ( Hex
     , fromString
     , toHexString
-    , toBytes
     , toUTF8String
+    , toBytes
     )
 
 {-| Providing robust hex string smart constructors/deconstructors.
@@ -61,7 +61,8 @@ toUTF8String hex =
             str
 
         Err _ ->
-            -- Another impossible case.
+            -- `Hex` can only be created with `fromString`, therefore this is
+            -- an impossible case and most likely an acceptable compromise.
             toHexString hex
 
 
@@ -71,8 +72,7 @@ toBytes : Hex -> Bytes
 toBytes hex =
     case HexConvert.toBytes (toHexString hex) of
         Nothing ->
-            -- `Hex` can only be created with `fromString`, therefore this is
-            -- an impossible case and most likely an acceptable compromise.
+            -- Another impossible case.
             BE.encode <| BE.unsignedInt8 0
 
         Just hexBytes ->

--- a/src/Hex/Extra.elm
+++ b/src/Hex/Extra.elm
@@ -1,0 +1,79 @@
+module Hex.Extra exposing
+    ( Hex
+    , fromString
+    , toHexString
+    , toBytes
+    , toUTF8String
+    )
+
+{-| Providing robust hex string smart constructors/deconstructors.
+
+@docs Hex, fromString, toHexString, toUTF8String, toBytes
+
+-}
+
+import Bytes exposing (Bytes)
+import Bytes.Encode as BE
+import Hex.Convert as HexConvert
+import Hex as HexBasic
+import String.UTF8 as UTF8
+
+
+{-| An opaque 'String' wrapper to ensure the underlying 'String' is a hex.
+-}
+type Hex =
+    Hex String
+
+
+{-| Smart constructor for the 'Hex' datatype. If the given 'String' is not in
+hex, it'll implicitly assume it as a UTF-8 encoded string, convert each
+character to its hex equivalent, and wrap the resulting string into a 'Hex'.
+-}
+fromString : String -> Hex
+fromString str =
+    case HexConvert.toBytes str of
+        Nothing ->
+            UTF8.toBytes str
+                |> List.map HexBasic.toString
+                |> String.concat
+                |> Hex
+
+        Just _ ->
+            Hex str
+
+
+{-| Unwrapper function for accessing the 'String' underneath.
+-}
+toHexString : Hex -> String
+toHexString hex =
+    case hex of
+        Hex str ->
+            str
+
+
+{-| A convenient helper function for UTF-8 decoding a 'Hex'. Usefult for
+Cardano token names.
+-}
+toUTF8String : Hex -> String
+toUTF8String hex =
+    case UTF8.toString (UTF8.toBytes <| toHexString hex) of
+        Ok str ->
+            str
+
+        Err _ ->
+            -- Another impossible case.
+            toHexString hex
+
+
+{-| For converting a 'Hex' into 'Bytes'.
+-}
+toBytes : Hex -> Bytes
+toBytes hex =
+    case HexConvert.toBytes (toHexString hex) of
+        Nothing ->
+            -- `Hex` can only be created with `fromString`, therefore this is
+            -- an impossible case and most likely an acceptable compromise.
+            BE.encode <| BE.unsignedInt8 0
+
+        Just hexBytes ->
+            hexBytes

--- a/tests/Hex/Convert/Extra.elm
+++ b/tests/Hex/Convert/Extra.elm
@@ -1,14 +1,9 @@
 module Hex.Convert.Extra exposing (fromString)
 
 import Bytes exposing (Bytes)
-import Hex.Convert as Hex
+import Hex.Extra as Hex
 
 
 fromString : String -> Bytes
 fromString str =
-    case Hex.toBytes str of
-        Nothing ->
-            Debug.todo <| "Hex.Convert.Extra.fromString: not a valid hex string: " ++ str
-
-        Just hex ->
-            hex
+    Hex.toBytes <| Hex.fromString str


### PR DESCRIPTION
Introducing `Hex` opaque datatype with helper functions and constructors
to provide acceptable guarantees for dealing with hex strings.

The `fromString` smart constructor implicitly treats non-hex strings as
UTF-8 encoded strings, converts each character to its hex equivalent and
wraps the resulting string under `Hex`.