### PR TITLE
[WIP] Implement Fixed Width Comparable Bytes

### DIFF
--- a/src/Bytes/Comparable.elm
+++ b/src/Bytes/Comparable.elm
@@ -25,8 +25,9 @@ import Hex.Convert as Hex
 
 {-| A custom `Bytes` type that is comparable with `==`.
 
-Useful as otherwise, the original `Bytes` type from `elm/bytes` package cannot be used to compare for equality with `==`.
-The phantom type parameter `a` indicates what type of Bytes are stored.
+Useful as otherwise, the original `Bytes` type from `elm/bytes` package cannot
+be used to compare for equality with `==`. The phantom type parameter `a` indicates
+what type of Bytes are stored.
 
 -}
 type Bytes a

--- a/src/Bytes/Fixed.elm
+++ b/src/Bytes/Fixed.elm
@@ -1,0 +1,136 @@
+module Bytes.Fixed exposing
+    ( Bytes16
+    , Bytes28
+    , Bytes32
+    , Bytes4
+    , Bytes64
+    , bytes16
+    , bytes28
+    , bytes32
+    , bytes4
+    , bytes64
+    )
+
+import Bytes as RawBytes
+import Bytes.Comparable as Bytes exposing (Any, Bytes)
+import Bytes.Decode as BD
+import Cbor.Decode as CD
+import Cbor.Decode.Extra as CD
+import Cbor.Encode as CE
+import Json.Decode as JD
+import Json.Encode as JE
+
+
+type Bytes4
+    = Bytes4 (Bytes Any)
+
+
+bytes4 : Utilities Bytes4
+bytes4 =
+    mkUtilitiesFor Bytes4 (\(Bytes4 bs) -> bs) 4
+
+
+type Bytes16
+    = Bytes16 (Bytes Any)
+
+
+bytes16 : Utilities Bytes16
+bytes16 =
+    mkUtilitiesFor Bytes16 (\(Bytes16 bs) -> bs) 16
+
+
+type Bytes28
+    = Bytes28 (Bytes Any)
+
+
+bytes28 : Utilities Bytes28
+bytes28 =
+    mkUtilitiesFor Bytes28 (\(Bytes28 bs) -> bs) 28
+
+
+type Bytes32
+    = Bytes32 (Bytes Any)
+
+
+bytes32 : Utilities Bytes32
+bytes32 =
+    mkUtilitiesFor Bytes32 (\(Bytes32 bs) -> bs) 32
+
+
+type Bytes64
+    = Bytes64 (Bytes Any)
+
+
+bytes64 : Utilities Bytes64
+bytes64 =
+    mkUtilitiesFor Bytes64 (\(Bytes64 bs) -> bs) 64
+
+
+
+-- Higher Order Helpers
+
+
+type alias Utilities t =
+    { fromBytes : Bytes Any -> Maybe t
+    , rawBytesDecoder : BD.Decoder t
+    , toBytes : t -> Bytes Any
+    , toCbor : t -> CE.Encoder
+    , cborDecoder : CD.Decoder t
+    , jsonDecoder : JD.Decoder t
+    , fromString : String -> Maybe t
+    , toString : t -> String
+    }
+
+
+mkUtilitiesFor : (Bytes Any -> t) -> (t -> Bytes Any) -> Int -> Utilities t
+mkUtilitiesFor bytesToData dataToBytes bytesCount =
+    let
+        strLength =
+            bytesCount * 2
+
+        fromComparableBytes =
+            mkFromBytes bytesCount >> Maybe.map bytesToData
+    in
+    { fromBytes = fromComparableBytes
+    , rawBytesDecoder = BD.bytes bytesCount |> BD.map (bytesToData << Bytes.fromBytes)
+    , toBytes = dataToBytes
+    , toCbor = dataToBytes >> Bytes.toCbor
+    , cborDecoder = CD.fromMaybe <| CD.map (fromComparableBytes << Bytes.fromBytes) CD.bytes
+    , jsonDecoder = mkJsonDecoder bytesCount |> JD.map bytesToData
+    , fromString = mkFromString strLength >> Maybe.map bytesToData
+    , toString = dataToBytes >> Bytes.toString
+    }
+
+
+mkFromBytes : Int -> (Bytes Any -> Maybe (Bytes Any))
+mkFromBytes bytesCount =
+    \bs ->
+        if Bytes.width bs == bytesCount then
+            Just bs
+
+        else
+            Nothing
+
+
+mkFromString : Int -> (String -> Maybe (Bytes Any))
+mkFromString strLength =
+    \hexStr ->
+        if String.length hexStr == strLength then
+            Bytes.fromString hexStr |> Maybe.map Bytes.toAny
+
+        else
+            Nothing
+
+
+mkJsonDecoder : Int -> JD.Decoder (Bytes Any)
+mkJsonDecoder bytesCount =
+    JD.string
+        |> JD.andThen
+            (\str ->
+                case mkFromString (bytesCount * 2) str of
+                    Just bytes ->
+                        JD.succeed bytes
+
+                    Nothing ->
+                        JD.fail "Invalid hex string."
+            )

--- a/src/Cardano/Address.elm
+++ b/src/Cardano/Address.elm
@@ -24,6 +24,7 @@ import Bitwise
 import Bytes as B
 import Bytes.Comparable as Bytes exposing (Bytes)
 import Bytes.Decode as BD
+import Bytes.Fixed exposing (Bytes28, bytes28)
 import Cbor.Decode as D
 import Cbor.Encode as E
 import Cbor.Encode.Extra as EE
@@ -67,8 +68,8 @@ Credentials are always one of two kinds: a direct public/private key pair, or a 
 
 -}
 type Credential
-    = VKeyHash (Bytes CredentialHash)
-    | ScriptHash (Bytes CredentialHash)
+    = VKeyHash CredentialHash
+    | ScriptHash CredentialHash
 
 
 {-| A StakeCredential represents the delegation and rewards withdrawal conditions associated with some stake address / account.
@@ -89,13 +90,13 @@ type alias StakeCredentialPointer =
 {-| Phantom type for 28-bytes credential hashes.
 This is a Blake2b-224 hash.
 -}
-type CredentialHash
-    = CredentialHash Never
+type alias CredentialHash =
+    Bytes28
 
 
 {-| Create a simple enterprise address, with only a payment credential and no stake credential.
 -}
-enterprise : NetworkId -> Bytes CredentialHash -> Address
+enterprise : NetworkId -> CredentialHash -> Address
 enterprise networkId credentials =
     Shelley
         { networkId = networkId
@@ -106,7 +107,7 @@ enterprise networkId credentials =
 
 {-| Create a simple script address, with only a payment credential and no stake credential.
 -}
-script : NetworkId -> Bytes CredentialHash -> Address
+script : NetworkId -> CredentialHash -> Address
 script networkId credentials =
     Shelley
         { networkId = networkId
@@ -176,35 +177,35 @@ toCbor address =
             case ( paymentCredential, stakeCredential ) of
                 -- (0) 0000.... PaymentKeyHash StakeKeyHash
                 ( VKeyHash paymentKeyHash, Just (InlineCredential (VKeyHash stakeKeyHash)) ) ->
-                    encodeAddress networkId "0" (Bytes.toString paymentKeyHash ++ Bytes.toString stakeKeyHash)
+                    encodeAddress networkId "0" (bytes28.toString paymentKeyHash ++ bytes28.toString stakeKeyHash)
 
                 -- (1) 0001.... ScriptHash StakeKeyHash
                 ( ScriptHash paymentScriptHash, Just (InlineCredential (VKeyHash stakeKeyHash)) ) ->
-                    encodeAddress networkId "1" (Bytes.toString paymentScriptHash ++ Bytes.toString stakeKeyHash)
+                    encodeAddress networkId "1" (bytes28.toString paymentScriptHash ++ bytes28.toString stakeKeyHash)
 
                 -- (2) 0010.... PaymentKeyHash ScriptHash
                 ( VKeyHash paymentKeyHash, Just (InlineCredential (ScriptHash stakeScriptHash)) ) ->
-                    encodeAddress networkId "2" (Bytes.toString paymentKeyHash ++ Bytes.toString stakeScriptHash)
+                    encodeAddress networkId "2" (bytes28.toString paymentKeyHash ++ bytes28.toString stakeScriptHash)
 
                 -- (3) 0011.... ScriptHash ScriptHash
                 ( ScriptHash paymentScriptHash, Just (InlineCredential (ScriptHash stakeScriptHash)) ) ->
-                    encodeAddress networkId "3" (Bytes.toString paymentScriptHash ++ Bytes.toString stakeScriptHash)
+                    encodeAddress networkId "3" (bytes28.toString paymentScriptHash ++ bytes28.toString stakeScriptHash)
 
                 -- (4) 0100.... PaymentKeyHash Pointer
                 ( VKeyHash paymentKeyHash, Just (PointerCredential _) ) ->
-                    encodeAddress networkId "4" (Bytes.toString paymentKeyHash ++ Debug.todo "encode pointer credential")
+                    encodeAddress networkId "4" (bytes28.toString paymentKeyHash ++ Debug.todo "encode pointer credential")
 
                 -- (5) 0101.... ScriptHash Pointer
                 ( ScriptHash paymentScriptHash, Just (PointerCredential _) ) ->
-                    encodeAddress networkId "5" (Bytes.toString paymentScriptHash ++ Debug.todo "encode pointer credential")
+                    encodeAddress networkId "5" (bytes28.toString paymentScriptHash ++ Debug.todo "encode pointer credential")
 
                 -- (6) 0110.... PaymentKeyHash ø
                 ( VKeyHash paymentKeyHash, Nothing ) ->
-                    encodeAddress networkId "6" (Bytes.toString paymentKeyHash)
+                    encodeAddress networkId "6" (bytes28.toString paymentKeyHash)
 
                 -- (7) 0111.... ScriptHash ø
                 ( ScriptHash paymentScriptHash, Nothing ) ->
-                    encodeAddress networkId "7" (Bytes.toString paymentScriptHash)
+                    encodeAddress networkId "7" (bytes28.toString paymentScriptHash)
 
         Reward stakeAddress ->
             stakeAddressToCbor stakeAddress
@@ -217,11 +218,11 @@ stakeAddressToCbor { networkId, stakeCredential } =
     case stakeCredential of
         -- (14) 1110.... StakeKeyHash
         VKeyHash stakeKeyHash ->
-            encodeAddress networkId "e" (Bytes.toString stakeKeyHash)
+            encodeAddress networkId "e" (bytes28.toString stakeKeyHash)
 
         -- (15) 1111.... ScriptHash
         ScriptHash stakeScriptHash ->
-            encodeAddress networkId "f" (Bytes.toString stakeScriptHash)
+            encodeAddress networkId "f" (bytes28.toString stakeScriptHash)
 
 
 encodeAddress : NetworkId -> String -> String -> E.Encoder
@@ -248,12 +249,12 @@ credentialToCbor stakeCredential =
         case stakeCredential of
             VKeyHash addrKeyHash ->
                 [ E.int 0
-                , Bytes.toCbor addrKeyHash
+                , bytes28.toCbor addrKeyHash
                 ]
 
             ScriptHash scriptHash ->
                 [ E.int 1
-                , Bytes.toCbor scriptHash
+                , bytes28.toCbor scriptHash
                 ]
 
 
@@ -312,7 +313,8 @@ decodeReward =
 
 
 {-| Address decoder from raw bytes. Internal use only.
-Cannot be compose with other decoders as it may not consume the correct number of bytes.
+Cannot be compose with other decoders as it may not consume the correct number
+of bytes.
 
 This needs a copy of the bytes of the address to compensate
 the absence of backtracking in bytes decoders.
@@ -324,62 +326,60 @@ decodeBytes bytesCopy =
     BD.unsignedInt8
         |> BD.andThen
             (\header ->
+                let
+                    ntwrk =
+                        networkIdFromHeader header
+
+                    baseDecoder payConstr stakeConstr =
+                        BD.map2
+                            (\payment stake -> base ntwrk (payConstr payment) (stakeConstr stake))
+                            bytes28.rawBytesDecoder
+                            bytes28.rawBytesDecoder
+                in
                 case Bitwise.shiftRightBy 4 header of
                     -- (0) 0000.... PaymentKeyHash StakeKeyHash
                     0 ->
-                        BD.map2
-                            (\payment stake -> base (networkIdFromHeader header) (VKeyHash payment) (VKeyHash stake))
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                        baseDecoder VKeyHash VKeyHash
 
                     -- (1) 0001.... ScriptHash StakeKeyHash
                     1 ->
-                        BD.map2
-                            (\payment stake -> base (networkIdFromHeader header) (ScriptHash payment) (VKeyHash stake))
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                        baseDecoder ScriptHash VKeyHash
 
                     -- (2) 0010.... PaymentKeyHash ScriptHash
                     2 ->
-                        BD.map2
-                            (\payment stake -> base (networkIdFromHeader header) (VKeyHash payment) (ScriptHash stake))
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                        baseDecoder VKeyHash ScriptHash
 
                     -- (3) 0011.... ScriptHash ScriptHash
                     3 ->
-                        BD.map2
-                            (\payment stake -> base (networkIdFromHeader header) (ScriptHash payment) (ScriptHash stake))
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                        baseDecoder ScriptHash ScriptHash
 
                     -- (4) 0100.... PaymentKeyHash Pointer
                     4 ->
                         BD.map2
                             (\payment ->
-                                pointer (networkIdFromHeader header) (VKeyHash payment)
+                                pointer ntwrk (VKeyHash payment)
                             )
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                            bytes28.rawBytesDecoder
                             (BD.map3 StakeCredentialPointer Word7.fromBytes Word7.fromBytes Word7.fromBytes)
 
                     -- (5) 0101.... ScriptHash Pointer
                     5 ->
                         BD.map2
                             (\payment ->
-                                pointer (networkIdFromHeader header) (ScriptHash payment)
+                                pointer ntwrk (ScriptHash payment)
                             )
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                            bytes28.rawBytesDecoder
                             (BD.map3 StakeCredentialPointer Word7.fromBytes Word7.fromBytes Word7.fromBytes)
 
                     -- (6) 0110.... PaymentKeyHash ø
                     6 ->
-                        BD.map (enterprise (networkIdFromHeader header))
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                        BD.map (enterprise ntwrk)
+                            bytes28.rawBytesDecoder
 
                     -- (7) 0111.... ScriptHash ø
                     7 ->
-                        BD.map (script (networkIdFromHeader header))
-                            (BD.map Bytes.fromBytes <| BD.bytes 28)
+                        BD.map (script ntwrk)
+                            bytes28.rawBytesDecoder
 
                     -- (8) 1000.... Byron
                     8 ->
@@ -388,13 +388,13 @@ decodeBytes bytesCopy =
 
                     -- (14) 1110.... StakeKeyHash
                     14 ->
-                        BD.map (\cred -> Reward <| StakeAddress (networkIdFromHeader header) cred)
-                            (BD.map (VKeyHash << Bytes.fromBytes) <| BD.bytes 28)
+                        BD.map (\cred -> Reward <| StakeAddress ntwrk cred)
+                            (BD.map VKeyHash bytes28.rawBytesDecoder)
 
                     -- (15) 1111.... ScriptHash
                     15 ->
                         BD.map (\cred -> Reward <| StakeAddress (networkIdFromHeader header) cred)
-                            (BD.map (ScriptHash << Bytes.fromBytes) <| BD.bytes 28)
+                            (BD.map ScriptHash bytes28.rawBytesDecoder)
 
                     _ ->
                         BD.fail

--- a/src/Cardano/MultiAsset.elm
+++ b/src/Cardano/MultiAsset.elm
@@ -10,6 +10,8 @@ module Cardano.MultiAsset exposing
 
 -}
 
+import Bytes.Comparable exposing (Any, Bytes)
+import Bytes.Fixed exposing (Bytes28)
 import Bytes.Map exposing (BytesMap)
 import Cbor.Encode as E
 import Cbor.Encode.Extra as EE
@@ -25,15 +27,15 @@ type alias MultiAsset =
 {-| Phantom type for 28-bytes policy id.
 This is a Blacke2b-224 hash.
 -}
-type PolicyId
-    = PolicyId Never
+type alias PolicyId =
+    Bytes28
 
 
 {-| Phantom type for asset names.
 This is a free-form bytes array of length <= 32 bytes.
 -}
 type AssetName
-    = AssetName Never
+    = Bytes Any
 
 
 {-| Create an empty [MultiAsset].

--- a/src/Cardano/Script.elm
+++ b/src/Cardano/Script.elm
@@ -14,7 +14,8 @@ module Cardano.Script exposing
 
 -}
 
-import Bytes.Comparable as Bytes exposing (Bytes)
+import Bytes.Comparable as Bytes exposing (Any, Bytes)
+import Bytes.Fixed exposing (Bytes28, bytes28)
 import Cbor.Encode as E
 import Cbor.Encode.Extra as EE
 
@@ -37,7 +38,7 @@ type Script
 <https://github.com/txpipe/pallas/blob/d1ac0561427a1d6d1da05f7b4ea21414f139201e/pallas-primitives/src/alonzo/model.rs#L772>
 -}
 type NativeScript
-    = ScriptPubkey (Bytes NativeScriptPubkeyHash)
+    = ScriptPubkey NativeScriptPubkeyHash
     | ScriptAll (List NativeScript)
     | ScriptAny (List NativeScript)
     | ScriptNofK Int (List NativeScript)
@@ -48,15 +49,15 @@ type NativeScript
 {-| Phantom type for 28-bytes native script public key hash.
 This is a Blake2b-224 hash.
 -}
-type NativeScriptPubkeyHash
-    = NativeScriptPubkeyHash Never
+type alias NativeScriptPubkeyHash =
+    Bytes28
 
 
 {-| A plutus script.
 -}
 type alias PlutusScript =
     { version : PlutusVersion
-    , script : Bytes ScriptCbor
+    , script : ScriptCbor
     }
 
 
@@ -69,8 +70,8 @@ type PlutusVersion
 
 {-| Phantom type describing the kind of bytes within a [PlutusScript] object.
 -}
-type ScriptCbor
-    = ScriptCbor Never
+type alias ScriptCbor =
+    Bytes Any
 
 
 {-| Cbor Encoder for [Script]
@@ -99,7 +100,7 @@ encodeNativeScript nativeScript =
         case nativeScript of
             ScriptPubkey addrKeyHash ->
                 [ E.int 0
-                , Bytes.toCbor addrKeyHash
+                , bytes28.toCbor addrKeyHash
                 ]
 
             ScriptAll nativeScripts ->

--- a/src/Cardano/Transaction.elm
+++ b/src/Cardano/Transaction.elm
@@ -41,6 +41,7 @@ module Cardano.Transaction exposing
 -}
 
 import Bytes.Comparable as Bytes exposing (Any, Bytes)
+import Bytes.Fixed exposing (Bytes16, Bytes28, Bytes32, Bytes4, Bytes64, bytes16, bytes28, bytes32, bytes4, bytes64)
 import Bytes.Map exposing (BytesMap)
 import Cardano.Address as Address exposing (Credential, CredentialHash, NetworkId, StakeAddress)
 import Cardano.Data as Data exposing (Data)
@@ -77,15 +78,15 @@ type alias TransactionBody =
     , certificates : List Certificate -- 4
     , withdrawals : List ( StakeAddress, Natural ) -- 5
     , update : Maybe Update -- 6
-    , auxiliaryDataHash : Maybe (Bytes AuxiliaryDataHash) -- 7
+    , auxiliaryDataHash : Maybe AuxiliaryDataHash -- 7
     , validityIntervalStart : Maybe Int -- 8
 
     -- TODO: Use a type that can have negative numbers instead
     -- and make MultiAsset only positive numbers?
     , mint : MultiAsset -- 9
-    , scriptDataHash : Maybe (Bytes ScriptDataHash) -- 11
+    , scriptDataHash : Maybe ScriptDataHash -- 11
     , collateral : List OutputReference -- 13
-    , requiredSigners : List (Bytes CredentialHash) -- 14
+    , requiredSigners : List CredentialHash -- 14
     , networkId : Maybe NetworkId -- 15
     , collateralReturn : Maybe Output -- 16
     , totalCollateral : Maybe Int -- 17
@@ -96,15 +97,15 @@ type alias TransactionBody =
 {-| Phantom type for auxiliary data hashes.
 This is a 32-bytes Blake2b-256 hash.
 -}
-type AuxiliaryDataHash
-    = AuxiliaryDataHash Never
+type alias AuxiliaryDataHash =
+    Bytes32
 
 
 {-| Phantom type for script data hashes.
 This is a 32-bytes Blake2b-256 hash.
 -}
-type ScriptDataHash
-    = ScriptDataHash Never
+type alias ScriptDataHash =
+    Bytes32
 
 
 {-| A Cardano transaction witness set.
@@ -118,10 +119,10 @@ type alias WitnessSet =
     { vkeywitness : Maybe (List VKeyWitness) -- 0
     , nativeScripts : Maybe (List NativeScript) -- 1
     , bootstrapWitness : Maybe (List BootstrapWitness) -- 2
-    , plutusV1Script : Maybe (List (Bytes ScriptCbor)) -- 3
+    , plutusV1Script : Maybe (List ScriptCbor) -- 3
     , plutusData : Maybe (List Data) -- 4
     , redeemer : Maybe (List Redeemer) -- 5
-    , plutusV2Script : Maybe (List (Bytes ScriptCbor)) -- 6
+    , plutusV2Script : Maybe (List ScriptCbor) -- 6
     }
 
 
@@ -206,44 +207,44 @@ type alias RationalNumber =
 
 {-| -}
 type alias VKeyWitness =
-    { vkey : Bytes Ed25519PublicKey -- 0
-    , signature : Bytes Ed25519Signature -- 1
+    { vkey : Ed25519PublicKey -- 0
+    , signature : Ed25519Signature -- 1
     }
 
 
 {-| -}
 type alias BootstrapWitness =
-    { publicKey : Bytes Ed25519PublicKey -- 0
-    , signature : Bytes Ed25519Signature -- 1
-    , chainCode : Bytes BootstrapWitnessChainCode -- 2
-    , attributes : Bytes BootstrapWitnessAttributes -- 3
+    { publicKey : Ed25519PublicKey -- 0
+    , signature : Ed25519Signature -- 1
+    , chainCode : BootstrapWitnessChainCode -- 2
+    , attributes : BootstrapWitnessAttributes -- 3
     }
 
 
 {-| Phantom type for ED25519 public keys, of length 32 bytes.
 -}
-type Ed25519PublicKey
-    = Ed25519PublicKey Never
+type alias Ed25519PublicKey =
+    Bytes32
 
 
 {-| Phantom type for ED25519 signatures, of length 64 bytes.
 -}
-type Ed25519Signature
-    = Ed25519Signature Never
+type alias Ed25519Signature =
+    Bytes64
 
 
 {-| Phantom type for [BootstrapWitness] chain code.
 It has a length of 32 bytes.
 -}
-type BootstrapWitnessChainCode
-    = BootstrapWitnessChainCode Never
+type alias BootstrapWitnessChainCode =
+    Bytes32
 
 
 {-| Phantom type for [BootstrapWitness] attributes.
 Bytes of this type can be of any length.
 -}
-type BootstrapWitnessAttributes
-    = BootstrapWitnessAttributes Never
+type alias BootstrapWitnessAttributes =
+    Bytes Any
 
 
 
@@ -266,7 +267,7 @@ type alias ScriptContext =
 {-| Characterizes the kind of script being executed and the associated resource.
 -}
 type ScriptPurpose
-    = SPMint { policyId : Bytes PolicyId }
+    = SPMint { policyId : PolicyId }
     | SPSpend OutputReference
     | SPWithdrawFrom Credential
     | SPPublish Certificate
@@ -283,13 +284,13 @@ Most of the time, they require signatures from specific keys.
 type Certificate
     = StakeRegistration { delegator : Credential }
     | StakeDeregistration { delegator : Credential }
-    | StakeDelegation { delegator : Credential, poolId : Bytes PoolId }
+    | StakeDelegation { delegator : Credential, poolId : PoolId }
     | PoolRegistration PoolParams
-    | PoolRetirement { poolId : Bytes PoolId, epoch : Natural }
+    | PoolRetirement { poolId : PoolId, epoch : Natural }
     | GenesisKeyDelegation
-        { genesisHash : Bytes GenesisHash
-        , genesisDelegateHash : Bytes GenesisDelegateHash
-        , vrfKeyHash : Bytes VrfKeyHash
+        { genesisHash : GenesisHash
+        , genesisDelegateHash : GenesisDelegateHash
+        , vrfKeyHash : VrfKeyHash
         }
     | MoveInstantaneousRewardsCert MoveInstantaneousReward
 
@@ -297,41 +298,41 @@ type Certificate
 {-| Phantom type for pool ID.
 This is a 28-bytes Blake2b-224 hash.
 -}
-type PoolId
-    = PoolId Never
+type alias PoolId =
+    Bytes28
 
 
 {-| Phantom type for Genesis hash.
 This is a 28-bytes Blake2b-224 hash.
 -}
-type GenesisHash
-    = GenesisHash Never
+type alias GenesisHash =
+    Bytes28
 
 
 {-| Phantom type for Genesis delegate hash.
 This is a 28-bytes Blake2b-224 hash.
 -}
-type GenesisDelegateHash
-    = GenesisDelegateHash Never
+type alias GenesisDelegateHash =
+    Bytes28
 
 
 {-| Phantom type for VRF key hash.
 This is a 32-bytes Blake2b-256 hash.
 -}
-type VrfKeyHash
-    = VrfKeyHash Never
+type alias VrfKeyHash =
+    Bytes32
 
 
 {-| Parameters for stake pool registration.
 -}
 type alias PoolParams =
-    { operator : Bytes PoolId
-    , vrfKeyHash : Bytes VrfKeyHash
+    { operator : PoolId
+    , vrfKeyHash : VrfKeyHash
     , pledge : Natural
     , cost : Natural
     , margin : UnitInterval
     , rewardAccount : StakeAddress
-    , poolOwners : List (Bytes CredentialHash)
+    , poolOwners : List CredentialHash
     , relays : List Relay
     , poolMetadata : Maybe PoolMetadata
     }
@@ -340,36 +341,36 @@ type alias PoolParams =
 {-| A pool's relay information.
 -}
 type Relay
-    = SingleHostAddr { port_ : Maybe Int, ipv4 : Maybe (Bytes IpV4), ipv6 : Maybe (Bytes IpV6) }
+    = SingleHostAddr { port_ : Maybe Int, ipv4 : Maybe IpV4, ipv6 : Maybe IpV6 }
     | SingleHostName { port_ : Maybe Int, dnsName : String }
     | MultiHostName { dnsName : String }
 
 
 {-| Phantom type for 4-bytes IPV4 addresses.
 -}
-type IpV4
-    = IpV4 Never
+type alias IpV4 =
+    Bytes4
 
 
 {-| Phantom type for 16-bytes IPV6 addresses.
 -}
-type IpV6
-    = IpV6 Never
+type alias IpV6 =
+    Bytes16
 
 
 {-| A pool's metadata hash.
 -}
 type alias PoolMetadata =
     { url : String -- tstr .size (0..64)
-    , poolMetadataHash : Bytes PoolMetadataHash
+    , poolMetadataHash : PoolMetadataHash
     }
 
 
 {-| Phantom type for 32-bytes pool metadata hash.
 This is a Blacke2b-256 hash.
 -}
-type PoolMetadataHash
-    = PoolMetadataHash Never
+type alias PoolMetadataHash =
+    Bytes32
 
 
 {-| Payload for [MoveInstantaneousRewardsCert].
@@ -441,10 +442,10 @@ encodeTransactionBody =
             >> E.nonEmptyField 4 List.isEmpty encodeCertificates .certificates
             >> E.nonEmptyField 5 List.isEmpty (E.ledgerAssociativeList Address.stakeAddressToCbor E.natural) .withdrawals
             >> E.optionalField 6 encodeUpdate .update
-            >> E.optionalField 7 Bytes.toCbor .auxiliaryDataHash
+            >> E.optionalField 7 bytes32.toCbor .auxiliaryDataHash
             >> E.optionalField 8 E.int .validityIntervalStart
             >> E.nonEmptyField 9 MultiAsset.isEmpty MultiAsset.toCbor .mint
-            >> E.optionalField 11 Bytes.toCbor .scriptDataHash
+            >> E.optionalField 11 bytes32.toCbor .scriptDataHash
             >> E.nonEmptyField 13 List.isEmpty encodeInputs .collateral
             >> E.nonEmptyField 14 List.isEmpty encodeRequiredSigners .requiredSigners
             >> E.optionalField 15 Address.encodeNetworkId .networkId
@@ -478,8 +479,8 @@ encodeVKeyWitness : VKeyWitness -> E.Encoder
 encodeVKeyWitness =
     E.tuple <|
         E.elems
-            >> E.elem Bytes.toCbor .vkey
-            >> E.elem Bytes.toCbor .signature
+            >> E.elem bytes32.toCbor .vkey
+            >> E.elem bytes64.toCbor .signature
 
 
 {-| -}
@@ -493,8 +494,8 @@ encodeBootstrapWitness : BootstrapWitness -> E.Encoder
 encodeBootstrapWitness =
     E.tuple <|
         E.elems
-            >> E.elem Bytes.toCbor .publicKey
-            >> E.elem Bytes.toCbor .signature
+            >> E.elem bytes32.toCbor .publicKey
+            >> E.elem bytes64.toCbor .signature
 
 
 {-| -}
@@ -533,33 +534,33 @@ encodeCertificate certificate =
             StakeDelegation { delegator, poolId } ->
                 [ E.int 2
                 , Address.credentialToCbor delegator
-                , Bytes.toCbor poolId
+                , bytes28.toCbor poolId
                 ]
 
             PoolRegistration poolParams ->
                 [ E.int 3
-                , Bytes.toCbor poolParams.operator
-                , Bytes.toCbor poolParams.vrfKeyHash
+                , bytes28.toCbor poolParams.operator
+                , bytes32.toCbor poolParams.vrfKeyHash
                 , E.natural poolParams.pledge
                 , E.natural poolParams.cost
                 , encodeRationalNumber poolParams.margin
                 , Address.stakeAddressToCbor poolParams.rewardAccount
-                , E.ledgerList Bytes.toCbor poolParams.poolOwners
+                , E.ledgerList bytes28.toCbor poolParams.poolOwners
                 , E.ledgerList encodeRelay poolParams.relays
                 , E.maybe encodePoolMetadata poolParams.poolMetadata
                 ]
 
             PoolRetirement { poolId, epoch } ->
                 [ E.int 4
-                , Bytes.toCbor poolId
+                , bytes28.toCbor poolId
                 , E.natural epoch
                 ]
 
             GenesisKeyDelegation { genesisHash, genesisDelegateHash, vrfKeyHash } ->
                 [ E.int 5
-                , Bytes.toCbor genesisHash
-                , Bytes.toCbor genesisDelegateHash
-                , Bytes.toCbor vrfKeyHash
+                , bytes28.toCbor genesisHash
+                , bytes28.toCbor genesisDelegateHash
+                , bytes32.toCbor vrfKeyHash
                 ]
 
             MoveInstantaneousRewardsCert moveInstantaneousReward ->
@@ -575,8 +576,8 @@ encodeRelay relay =
             SingleHostAddr { port_, ipv4, ipv6 } ->
                 [ E.int 0
                 , E.maybe E.int port_
-                , E.maybe Bytes.toCbor ipv4
-                , E.maybe Bytes.toCbor ipv6
+                , E.maybe bytes4.toCbor ipv4
+                , E.maybe bytes16.toCbor ipv6
                 ]
 
             SingleHostName { port_, dnsName } ->
@@ -596,7 +597,7 @@ encodePoolMetadata =
     E.tuple <|
         E.elems
             >> E.elem E.string .url
-            >> E.elem Bytes.toCbor .poolMetadataHash
+            >> E.elem bytes32.toCbor .poolMetadataHash
 
 
 encodeMoveInstantaneousReward : MoveInstantaneousReward -> E.Encoder
@@ -629,9 +630,9 @@ encodeRewardTarget target =
 
 
 {-| -}
-encodeRequiredSigners : List (Bytes CredentialHash) -> E.Encoder
+encodeRequiredSigners : List CredentialHash -> E.Encoder
 encodeRequiredSigners =
-    E.ledgerList Bytes.toCbor
+    E.ledgerList bytes28.toCbor
 
 
 {-| -}
@@ -748,7 +749,7 @@ decodeBody =
             -- update
             >> D.optionalField 6 (D.oneOf [ decodeUpdate, D.failWith "Failed to decode protocol update" ])
             -- metadata hash
-            >> D.optionalField 7 (D.oneOf [ D.map Bytes.fromBytes D.bytes, D.failWith "Failed to decode metadata hash" ])
+            >> D.optionalField 7 (D.oneOf [ bytes32.cborDecoder, D.failWith "Failed to decode metadata hash" ])
 
 
 decodeCertificate : D.Decoder Certificate
@@ -776,7 +777,7 @@ decodeCertificateHelper length id =
             D.map2
                 (\cred poolId -> StakeDelegation { delegator = cred, poolId = poolId })
                 decodeStakeCredential
-                (D.map Bytes.fromBytes D.bytes)
+                bytes28.cborDecoder
 
         -- pool_registration = (3, pool_params)
         -- pool_params is of size 9
@@ -786,7 +787,7 @@ decodeCertificateHelper length id =
         -- pool_retirement = (4, pool_keyhash, epoch)
         ( 3, 4 ) ->
             D.map2 (\poolId epoch -> PoolRetirement { poolId = poolId, epoch = epoch })
-                (D.map Bytes.fromBytes D.bytes)
+                bytes28.cborDecoder
                 D.natural
 
         -- genesis_key_delegation = (5, genesishash, genesis_delegate_hash, vrf_keyhash)
@@ -799,9 +800,9 @@ decodeCertificateHelper length id =
                         , vrfKeyHash = vrfKeyHash
                         }
                 )
-                (D.map Bytes.fromBytes D.bytes)
-                (D.map Bytes.fromBytes D.bytes)
-                (D.map Bytes.fromBytes D.bytes)
+                bytes28.cborDecoder
+                bytes28.cborDecoder
+                bytes32.cborDecoder
 
         -- move_instantaneous_rewards_cert = (6, move_instantaneous_reward)
         ( 2, 6 ) ->
@@ -828,11 +829,11 @@ decodeStakeCredential =
                             (\id ->
                                 if id == 0 then
                                     -- If the id is 0, it's a vkey hash
-                                    D.map (Address.VKeyHash << Bytes.fromBytes) D.bytes
+                                    D.map Address.VKeyHash bytes28.cborDecoder
 
                                 else if id == 1 then
                                     -- If the id is 1, it's a script hash
-                                    D.map (Address.ScriptHash << Bytes.fromBytes) D.bytes
+                                    D.map Address.ScriptHash bytes28.cborDecoder
 
                                 else
                                     D.fail
@@ -846,13 +847,13 @@ decodeStakeCredential =
 decodePoolParams : D.Decoder PoolParams
 decodePoolParams =
     D.succeed PoolParams
-        |> D.keep (D.oneOf [ D.map Bytes.fromBytes D.bytes, D.failWith "Failed to decode operator" ])
-        |> D.keep (D.oneOf [ D.map Bytes.fromBytes D.bytes, D.failWith "Failed to decode vrfkeyhash" ])
+        |> D.keep (D.oneOf [ bytes28.cborDecoder, D.failWith "Failed to decode operator" ])
+        |> D.keep (D.oneOf [ bytes32.cborDecoder, D.failWith "Failed to decode vrfkeyhash" ])
         |> D.keep (D.oneOf [ D.natural, D.failWith "Failed to decode pledge" ])
         |> D.keep D.natural
         |> D.keep (D.oneOf [ decodeRational, D.failWith "Failed to decode rational" ])
         |> D.keep (D.oneOf [ Address.decodeReward, D.failWith "Failed to decode reward" ])
-        |> D.keep (D.list (D.map Bytes.fromBytes D.bytes))
+        |> D.keep (D.list bytes28.cborDecoder)
         |> D.keep (D.list <| D.oneOf [ decodeRelay, D.failWith "Failed to decode Relay" ])
         |> D.keep (D.oneOf [ D.maybe decodePoolMetadata, D.failWith "Failed to decode pool metadata" ])
 
@@ -887,8 +888,8 @@ decodeRelayHelper length id =
         ( 4, 0 ) ->
             D.map3 (\port_ ipv4 ipv6 -> SingleHostAddr { port_ = port_, ipv4 = ipv4, ipv6 = ipv6 })
                 (D.maybe D.int)
-                (D.maybe <| D.map Bytes.fromBytes D.bytes)
-                (D.maybe <| D.map Bytes.fromBytes D.bytes)
+                (D.maybe bytes4.cborDecoder)
+                (D.maybe bytes16.cborDecoder)
 
         -- single_host_name = ( 1, port / null, dns_name )  -- An A or AAAA DNS record
         ( 3, 1 ) ->
@@ -915,7 +916,7 @@ decodePoolMetadata =
     D.tuple PoolMetadata <|
         D.elems
             >> D.elem D.string
-            >> D.elem (D.map Bytes.fromBytes D.bytes)
+            >> D.elem bytes32.cborDecoder
 
 
 decodeMoveInstantaneousRewards : D.Decoder MoveInstantaneousReward
@@ -1046,15 +1047,11 @@ decodeWitness =
 decodeVKeyWitness : D.Decoder VKeyWitness
 decodeVKeyWitness =
     D.tuple
-        (\vkey sig ->
-            { vkey = Bytes.fromBytes vkey
-            , signature = Bytes.fromBytes sig
-            }
+        VKeyWitness
+        (D.elems
+            >> D.elem bytes32.cborDecoder
+            >> D.elem bytes64.cborDecoder
         )
-    <|
-        D.elems
-            >> D.elem D.bytes
-            >> D.elem D.bytes
 
 
 decodeNativeScript : D.Decoder NativeScript
@@ -1065,19 +1062,13 @@ decodeNativeScript =
 decodeBootstrapWitness : D.Decoder BootstrapWitness
 decodeBootstrapWitness =
     D.tuple
-        (\pubkey sig chainCode attr ->
-            { publicKey = Bytes.fromBytes pubkey
-            , signature = Bytes.fromBytes sig
-            , chainCode = Bytes.fromBytes chainCode
-            , attributes = Bytes.fromBytes attr
-            }
+        BootstrapWitness
+        (D.elems
+            >> D.elem bytes32.cborDecoder
+            >> D.elem bytes64.cborDecoder
+            >> D.elem bytes32.cborDecoder
+            >> D.elem (D.map Bytes.fromBytes D.bytes)
         )
-    <|
-        D.elems
-            >> D.elem D.bytes
-            >> D.elem D.bytes
-            >> D.elem D.bytes
-            >> D.elem D.bytes
 
 
 

--- a/src/Cardano/Transaction/Builder.elm
+++ b/src/Cardano/Transaction/Builder.elm
@@ -186,12 +186,12 @@ addFee amount body =
     { body | fee = Just amount }
 
 
-scriptDataHash : Bytes ScriptDataHash -> Tx -> Tx
+scriptDataHash : ScriptDataHash -> Tx -> Tx
 scriptDataHash dataHash (Tx inner) =
     inner |> updateBody (addScriptDataHash dataHash)
 
 
-addScriptDataHash : Bytes ScriptDataHash -> TransactionBody -> TransactionBody
+addScriptDataHash : ScriptDataHash -> TransactionBody -> TransactionBody
 addScriptDataHash dataHash body =
     { body | scriptDataHash = Just dataHash }
 
@@ -208,12 +208,12 @@ addCollateral newInput body =
     }
 
 
-requiredSigner : Bytes CredentialHash -> Tx -> Tx
+requiredSigner : CredentialHash -> Tx -> Tx
 requiredSigner signer (Tx inner) =
     inner |> updateBody (addRequiredSigner signer)
 
 
-addRequiredSigner : Bytes CredentialHash -> TransactionBody -> TransactionBody
+addRequiredSigner : CredentialHash -> TransactionBody -> TransactionBody
 addRequiredSigner signer body =
     { body
         | requiredSigners = signer :: body.requiredSigners

--- a/src/Cbor/Decode/Extra.elm
+++ b/src/Cbor/Decode/Extra.elm
@@ -26,7 +26,7 @@ natural =
             )
 
 
-failWith : String -> D.Decoder a
+failWith : String -> Decoder a
 failWith msg =
     D.oneOf [ D.map Bytes.fromBytes D.raw, D.succeed <| Bytes.fromStringUnchecked "..." ]
         |> D.andThen
@@ -37,3 +37,16 @@ failWith msg =
                 in
                 D.fail
             )
+
+
+fromMaybe : Decoder (Maybe a) -> Decoder a
+fromMaybe =
+    D.andThen
+        (\mValue ->
+            case mValue of
+                Just v ->
+                    D.succeed v
+
+                Nothing ->
+                    D.fail
+        )


### PR DESCRIPTION
Experimental PR to discuss implications of having datatypes for fixed byte counts (and possibly remove the phantom type of `Bytes`, as laid out in #29).

Here I've tried to demonstrate how we can use a typeclass-like `Utilities` type alias to abstract common encoders/decoders and minimize code changes down the line.

As a potential downside, datatypes like `CredentialHash`, `PolicyId` etc. are defined as type aliases of their fixed bytes counterpart.