### PR TITLE
WIP make cip30 complete

### DIFF
--- a/examples/wallet-cip30/src/Main.elm
+++ b/examples/wallet-cip30/src/Main.elm
@@ -267,36 +267,21 @@ update msg model =
             ( model, toWallet (Cip30.encodeRequest (Cip30.getNetworkId wallet)) )
 
         GetUtxosPaginateButtonClicked wallet ->
-            -- Gero does not paginate
-            -- Flint does not paginate
-            -- NuFi does not paginate
             ( model, toWallet <| Cip30.encodeRequest <| Cip30.getUtxos wallet { amount = Nothing, paginate = Just { page = 0, limit = 2 } } )
 
         GetUtxosAmountButtonClicked wallet ->
-            -- Lace picks at random (fun!)
-            -- Gero does not handle the amount parameter
-            -- NuFi does not handle the amount parameter
             ( model, toWallet <| Cip30.encodeRequest <| Cip30.getUtxos wallet { amount = Just (ECValue.onlyLovelace <| N.fromSafeInt 14000000), paginate = Nothing } )
 
         GetCollateralButtonClicked wallet ->
-            -- Typhon crashes with the amounts
-            -- Nami crashes as the method does not exist
             ( model, toWallet <| Cip30.encodeRequest <| Cip30.getCollateral wallet { amount = N.fromSafeInt 3000000 } )
 
         GetBalanceButtonClicked wallet ->
-            -- Eternl has sometimes? a weird response
             ( model, toWallet (Cip30.encodeRequest (Cip30.getBalance wallet)) )
 
         GetUsedAddressesButtonClicked wallet ->
             ( model, toWallet (Cip30.encodeRequest (Cip30.getUsedAddresses wallet { paginate = Nothing })) )
 
         GetUnusedAddressesButtonClicked wallet ->
-            -- Lace does not return any unused address
-            -- Flint returns the same for unused address as used address
-            -- Typhon returns the same for unused address and used address
-            -- Eternl returns the same
-            -- Eternl and Typhon do not return the same addresses while being on the same wallet?
-            -- Nami returns no unused address
             ( model, toWallet (Cip30.encodeRequest (Cip30.getUnusedAddresses wallet)) )
 
         GetChangeAddressButtonClicked wallet ->

--- a/examples/wallet-cip30/src/Main.elm
+++ b/examples/wallet-cip30/src/Main.elm
@@ -3,6 +3,7 @@ port module Main exposing (..)
 import Browser
 import Bytes.Comparable as Bytes
 import Bytes.Encode
+import Cardano.Address as Address exposing (Address)
 import Cardano.Cip30 as Cip30
 import Cardano.Value as ECValue
 import Dict exposing (Dict)
@@ -52,7 +53,7 @@ type Msg
 type alias Model =
     { availableWallets : List Cip30.WalletDescriptor
     , connectedWallets : Dict String Cip30.Wallet
-    , rewardAddress : Maybe { walletId : String, address : String }
+    , rewardAddress : Maybe { walletId : String, address : Address }
     , lastApiResponse : String
     , lastError : String
     }
@@ -94,7 +95,7 @@ update msg model =
 
                 Ok (Cip30.ApiResponse { walletId } (Cip30.NetworkId networkId)) ->
                     ( { model
-                        | lastApiResponse = "wallet: " ++ walletId ++ ", network id: " ++ String.fromInt networkId
+                        | lastApiResponse = "wallet: " ++ walletId ++ ", network id: " ++ Debug.toString networkId
                         , lastError = ""
                       }
                     , Cmd.none
@@ -146,7 +147,7 @@ update msg model =
 
                 Ok (Cip30.ApiResponse { walletId } (Cip30.UsedAddresses usedAddresses)) ->
                     ( { model
-                        | lastApiResponse = "wallet: " ++ walletId ++ ", used addresses:\n" ++ String.join "\n" usedAddresses
+                        | lastApiResponse = "wallet: " ++ walletId ++ ", used addresses:\n" ++ String.join "\n" (List.map Debug.toString usedAddresses)
                         , lastError = ""
                       }
                     , Cmd.none
@@ -154,7 +155,7 @@ update msg model =
 
                 Ok (Cip30.ApiResponse { walletId } (Cip30.UnusedAddresses unusedAddresses)) ->
                     ( { model
-                        | lastApiResponse = "wallet: " ++ walletId ++ ", unused addresses:\n" ++ String.join "\n" unusedAddresses
+                        | lastApiResponse = "wallet: " ++ walletId ++ ", unused addresses:\n" ++ String.join "\n" (List.map Debug.toString unusedAddresses)
                         , lastError = ""
                       }
                     , Cmd.none
@@ -162,7 +163,7 @@ update msg model =
 
                 Ok (Cip30.ApiResponse { walletId } (Cip30.ChangeAddress changeAddress)) ->
                     ( { model
-                        | lastApiResponse = "wallet: " ++ walletId ++ ", change address:\n" ++ changeAddress
+                        | lastApiResponse = "wallet: " ++ walletId ++ ", change address:\n" ++ Debug.toString changeAddress
                         , lastError = ""
                       }
                     , Cmd.none
@@ -170,7 +171,7 @@ update msg model =
 
                 Ok (Cip30.ApiResponse { walletId } (Cip30.RewardAddresses rewardAddresses)) ->
                     ( { model
-                        | lastApiResponse = "wallet: " ++ walletId ++ ", reward addresses:\n" ++ String.join "\n" rewardAddresses
+                        | lastApiResponse = "wallet: " ++ walletId ++ ", reward addresses:\n" ++ String.join "\n" (List.map Debug.toString rewardAddresses)
                         , rewardAddress = List.head rewardAddresses |> Maybe.map (\addr -> { walletId = walletId, address = addr })
                         , lastError = ""
                       }
@@ -259,7 +260,7 @@ update msg model =
                         , toWallet <|
                             Cip30.encodeRequest <|
                                 Cip30.signData wallet
-                                    { addr = address
+                                    { addr = Address.toBytes address |> Bytes.toString
                                     , payload = Bytes.fromBytes <| Bytes.Encode.encode (Bytes.Encode.unsignedInt8 42)
                                     }
                         )

--- a/examples/wallet-cip30/src/Main.elm
+++ b/examples/wallet-cip30/src/Main.elm
@@ -246,7 +246,7 @@ update msg model =
         GetCollateralButtonClicked wallet ->
             -- Typhon crashes with the amounts
             -- Nami crashes as the method does not exist
-            ( model, toWallet <| Cip30.encodeRequest <| Cip30.getCollateral wallet { amount = ECValue.onlyLovelace <| N.fromSafeInt 3000000 } )
+            ( model, toWallet <| Cip30.encodeRequest <| Cip30.getCollateral wallet { amount = N.fromSafeInt 3000000 } )
 
         GetBalanceButtonClicked wallet ->
             -- Eternl has sometimes? a weird response

--- a/src/Bytes/Comparable.elm
+++ b/src/Bytes/Comparable.elm
@@ -75,7 +75,7 @@ width (Bytes str) =
 -}
 fromString : String -> Maybe (Bytes a)
 fromString str =
-    str |> Hex.toBytes |> Maybe.map (always <| Bytes str)
+    str |> Hex.toBytes |> Maybe.map (always <| Bytes (String.toLower str))
 
 
 {-| Same as [fromString] except it does not check that the hex-encoded string is well formed.

--- a/src/Cardano.elm
+++ b/src/Cardano.elm
@@ -1312,6 +1312,11 @@ processOtherInfo otherInfo =
 Only UTxOs at the provided whitelist of addresses are viable.
 Only UTxOs containing only Ada, without other CNT or datums are viable.
 
+Actually since cip40 and Vasil upgrade, any utxo can be used,
+as long as the difference with the collateral output is only ada.
+
+TODO: So we need another coin selection algo, specialized for collateral.
+
 -}
 computeCollateralSelection :
     Utxo.RefDict Output

--- a/src/Cardano/Cip30.elm
+++ b/src/Cardano/Cip30.elm
@@ -34,9 +34,11 @@ import Cardano.Value as ECValue
 import Cbor exposing (CborItem)
 import Cbor.Decode
 import Cbor.Encode
+import Cbor.Encode.Extra
 import Hex.Convert
 import Json.Decode as JDecode exposing (Decoder, Value)
 import Json.Encode as JEncode
+import Natural exposing (Natural)
 
 
 {-| The type returned when asking for available wallets.
@@ -139,11 +141,11 @@ More info about why that is in the [CIP 30 spec][cip-collateral].
 [cip-collateral]: https://cips.cardano.org/cips/cip30/#apigetcollateralparamsamountcborcoinpromisetransactionunspentoutputnull
 
 -}
-getCollateral : Wallet -> { amount : ECValue.Value } -> Request
+getCollateral : Wallet -> { amount : Natural } -> Request
 getCollateral wallet { amount } =
     let
         params =
-            JEncode.object [ ( "amount", ECValue.encode amount |> encodeCborHex ) ]
+            JEncode.object [ ( "amount", Cbor.Encode.Extra.natural amount |> encodeCborHex ) ]
     in
     apiRequest wallet "getCollateral" [ params ]
 

--- a/src/Cardano/Cip30.elm
+++ b/src/Cardano/Cip30.elm
@@ -472,6 +472,8 @@ networkIdDecoder =
         |> JDecode.andThen (Maybe.map JDecode.succeed >> Maybe.withDefault (JDecode.fail "unknown network id"))
 
 
+{-| JSON decoder for an [Address] encoded as hexadecimal string.
+-}
 addressDecoder : Decoder Address
 addressDecoder =
     JDecode.string

--- a/src/Cardano/Cip30.elm
+++ b/src/Cardano/Cip30.elm
@@ -30,7 +30,7 @@ import Bytes.Comparable as Bytes exposing (Bytes)
 import Cardano.Address as Address exposing (Address, NetworkId)
 import Cardano.Transaction as Transaction exposing (Transaction)
 import Cardano.Utxo as Utxo
-import Cardano.Value as ECValue
+import Cardano.Value as CValue
 import Cbor exposing (CborItem)
 import Cbor.Decode
 import Cbor.Encode
@@ -124,11 +124,11 @@ getNetworkId wallet =
 
 {-| Get a list of UTxOs in the wallet.
 -}
-getUtxos : Wallet -> { amount : Maybe ECValue.Value, paginate : Maybe Paginate } -> Request
+getUtxos : Wallet -> { amount : Maybe CValue.Value, paginate : Maybe Paginate } -> Request
 getUtxos wallet { amount, paginate } =
     apiRequest wallet
         "getUtxos"
-        [ encodeMaybe (\a -> ECValue.encode a |> encodeCborHex) amount
+        [ encodeMaybe (\a -> CValue.encode a |> encodeCborHex) amount
         , encodeMaybe encodePaginate paginate
         ]
 
@@ -295,7 +295,7 @@ type ApiResponse
     | NetworkId NetworkId
     | WalletUtxos (Maybe (List Utxo))
     | Collateral (Maybe (List Utxo))
-    | WalletBalance ECValue.Value
+    | WalletBalance CValue.Value
     | UsedAddresses (List Address)
     | UnusedAddresses (List Address)
     | ChangeAddress Address
@@ -422,7 +422,7 @@ apiDecoder method walletId =
 
         "getBalance" ->
             JDecode.map (\b -> ApiResponse { walletId = walletId } (WalletBalance b))
-                (JDecode.field "response" <| hexCborDecoder ECValue.fromCbor)
+                (JDecode.field "response" <| hexCborDecoder CValue.fromCbor)
 
         "getUsedAddresses" ->
             JDecode.map (\r -> ApiResponse { walletId = walletId } (UsedAddresses r))


### PR DESCRIPTION
I’ve started by replacing all the previously using `CborItem` by actual elm-cardano types now that we have decoders for all that stuff. I think the final missing parts are now the signature parts, so `api.signTx()` and `api.submitTx()`.

These signature apis rely on CIP8 (cose stuff). So maybe I can merge this in a still unfinished state, because it has some useful additions in the Address module. Or I just finish it all here and embed CIP8 in this PR. I mean it makes sense since we need a place to test it anyway, so testing it with wallet signatures via cip30 is fine.

Also it seems that Gero wallet makes the wallet detection crash for all other wallets. I have to look into that more.