### PR TITLE
Canonical CBOR encoding of Plutus Data

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -81,13 +81,13 @@ config =
             , "Cbor.Encode.beginString"
             , "Cbor.Encode.beginBytes"
             ]
-          , [ "Cbor.Encode.Extra", "Cardano.Data"  ]
+          , [ "Cbor.Encode.Extra" ]
           )
         -- Hardware Wallets need Map keys sorted in a special order
         , ( [ "Cbor.Encode.associativeList"
             , "Cbor.Encode.dict"
             ]
-          , [ "Cbor.Encode.Extra", "Cardano.Data"  ]
+          , [ "Cbor.Encode.Extra" ]
           )
         ]
     ]

--- a/src/Cardano/Data.elm
+++ b/src/Cardano/Data.elm
@@ -54,7 +54,7 @@ toCbor data =
                     { ixNat = ixNat, fields = fields }
 
         Map xs ->
-            E.associativeList toCbor toCbor xs
+            EE.associativeList toCbor toCbor xs
 
         List xs ->
             E.list toCbor xs

--- a/src/Cbor/Encode/Extra.elm
+++ b/src/Cbor/Encode/Extra.elm
@@ -1,14 +1,14 @@
 module Cbor.Encode.Extra exposing
     ( natural, integer
     , nonEmptyField
-    , associativeList, indefiniteList
+    , associativeList, indefiniteList, beginBytes
     )
 
 {-| Extra CBOR encoding utility functions.
 
 @docs natural, integer
 @docs nonEmptyField
-@docs associativeList, indefiniteList
+@docs associativeList, indefiniteList, beginBytes
 
 -}
 
@@ -159,3 +159,10 @@ toCanonicalKey encodeKey k =
 indefiniteList : (a -> E.Encoder) -> List a -> E.Encoder
 indefiniteList =
     E.indefiniteList
+
+
+{-| If you really need to build bytes with indefinite arrays.
+-}
+beginBytes : E.Encoder
+beginBytes =
+    E.beginBytes

--- a/tests/Cardano/DataTests.elm
+++ b/tests/Cardano/DataTests.elm
@@ -67,7 +67,10 @@ suite =
                 Constr Natural.zero []
             , testEncode "80" <|
                 List []
-            , testEncode "9F010203FF" <|
+
+            -- , testEncode "9F010203FF" <|
+            -- Now using definite length instead of indefinite length
+            , testEncode "83010203" <|
                 List [ Int Integer.one, Int Integer.two, Int Integer.three ]
             , testEncode "A0" <|
                 Map []
@@ -83,7 +86,10 @@ suite =
                 Int (Integer.fromSafeString "-0x010000000000000001")
             , testEncode "40" <|
                 (Bytes <| fromU8 [])
-            , testEncode "D87A9F21D87E9FD87C9F2143C2599BFF01FFD87C9F41B19F0044A06D8DCBFF40FFFF" <|
+
+            -- , testEncode "D87A9F21D87E9FD87C9F2143C2599BFF01FFD87C9F41B19F0044A06D8DCBFF40FFFF" <|
+            -- Now using definite length instead of indefinite length
+            , testEncode "d87a8321d87e82d87c822143c2599b01d87c8341b1820044a06d8dcb40" <|
                 Constr Natural.one
                     [ Int Integer.negativeTwo
                     , Constr Natural.five [ Constr Natural.three [ Int Integer.negativeTwo, Bytes (fromU8 [ 0xC2, 0x59, 0x9B ]) ], Int Integer.one ]


### PR DESCRIPTION
It seems the decoding of Plutus Data by the node is way more lenient than I previously thought.

https://github.com/IntersectMBO/plutus/blob/b086464584f2684658633b375283994dbe04bef8/plutus-core/plutus-core/src/PlutusCore/Data.hs#L178

It will accept definite or indefinite length encoding, with the exeption of long bytes (longer than 64bytes) that must be encoded with indefinite length.

So in order to make our encoders even more compliant with CIP21, prescribing canonical encoding for Hardware Wallet compatibility, I’ve rewritten the encoders of Data to use definite length encoding. And the Map is also encoded canonically, meaning no duplicate, and a special ordering of the keys.