### PR TITLE
Improve CIP30 error handling

### DIFF
--- a/examples/wallet-cip30/src/Main.elm
+++ b/examples/wallet-cip30/src/Main.elm
@@ -236,8 +236,8 @@ update msg model =
                     , Cmd.none
                     )
 
-                Ok (Cip30.Error error) ->
-                    ( { model | lastError = error }, Cmd.none )
+                Ok (Cip30.ApiError error) ->
+                    ( { model | lastError = Debug.toString error }, Cmd.none )
 
                 Ok (Cip30.UnhandledResponseType error) ->
                     ( { model | lastError = error }, Cmd.none )


### PR DESCRIPTION
CIP30 errors are now parsed to return `{ code : Int, info : String }`.